### PR TITLE
Fix imports & pypi package definition

### DIFF
--- a/cad/models/postprocessing.py
+++ b/cad/models/postprocessing.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-from consistencydecoder import ConsistencyDecoder
 
 from cad.utils.image_processing import remap_image_torch
 
@@ -38,12 +37,17 @@ class SD1_5VAEDecoderPostProcessing(SD1_5VAEPostProcessing):
             return remap_image_torch(self.vae.decode(x).sample.detach())
 
 
-class SD1_5VAEConsistencyProcessing(SD1_5VAEPostProcessing):
-    def __init__(self, channel_wise_normalisation=False):
-        super().__init__(channel_wise_normalisation=channel_wise_normalisation)
-        self.consistency = ConsistencyDecoder()
+try:
+    from consistencydecoder import ConsistencyDecoder
 
-    def forward(self, x):
-        x = super().forward(x)
-        with torch.no_grad():
-            return remap_image_torch(self.consistency(x).detach())
+    class SD1_5VAEConsistencyProcessing(SD1_5VAEPostProcessing):
+        def __init__(self, channel_wise_normalisation=False):
+            super().__init__(channel_wise_normalisation=channel_wise_normalisation)
+            self.consistency = ConsistencyDecoder()
+
+        def forward(self, x):
+            x = super().forward(x)
+            with torch.no_grad():
+                return remap_image_torch(self.consistency(x).detach())
+except ImportError:
+    pass

--- a/cad/pipe.py
+++ b/cad/pipe.py
@@ -13,9 +13,13 @@ from cad.models.samplers import (
 )
 
 from cad.models.postprocessing import (
-    SD1_5VAEConsistencyProcessing,
     SD1_5VAEDecoderPostProcessing,
 )
+
+try:
+    from cad.models.postprocessing import SD1_5VAEConsistencyProcessing
+except ImportError:
+    pass
 
 from cad.models.schedulers import (
     SigmoidScheduler,
@@ -45,7 +49,10 @@ MODELS = {
 
 def get_postprocessing(postprocessing_name):
     if postprocessing_name == "consistency-decoder":
-        return SD1_5VAEConsistencyProcessing()
+        try:
+            return SD1_5VAEConsistencyProcessing()
+        except:
+            raise ImportError("ConsistencyDecoder not found")
     elif postprocessing_name == "sd_1_5_vae":
         vae = AutoencoderKL.from_pretrained(
             "benjamin-paine/stable-diffusion-v1-5", subfolder="vae"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     description="Package for the CAD diffusion model",
     author="Nicolas Dufour",
     # packages=find_packages(exclude=["tests*"]),
+    python_requires=">=3.11",
     install_requires=[
         "torch",
         "torchvision",
@@ -18,6 +19,7 @@ setup(
         "huggingface_hub",
     ],
     packages=["cad"],
+    package_data={"cad": ["**/*"]},
     include_package_data=True,
     extras_require={
         "train": [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "einops",
         "transformers",
         "diffusers",
-        "huggingface_hub",
+        "huggingface_hub>=0.23",
     ],
     packages=["cad"],
     package_data={"cad": ["**/*"]},


### PR DESCRIPTION
I added some try / except around the ConsistencyEncoder declaration to manage the missing library.

I also added a minimal python version (required for the package) and all the subfolders in the package definiton (currently only .py files in the root are considered by setuptools)